### PR TITLE
Remove python 2.7 environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 cache:
 - pip
 python:
-- '2.7'
 - '3.4'
 - '3.5'
 - 3.5-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,6 @@ If you're hitting a bug in kojak or just want to experiment with adding a featur
 - [pbr](https://docs.openstack.org/pbr/latest/)
 - [flake8](http://flake8.pycqa.org/en/latest/)
 - [tox](https://tox.readthedocs.io/en/latest/)
-- python2.7+
 
 #### Cloning
 
@@ -137,7 +136,7 @@ $ tox -e pep8
 
 Unit tests:
 ```shell
-$ tox # by default run tests en python 2.7, 3.4, 3.5, 3.6
+$ tox # by default run tests en python 3.4, 3.5, 3.6
 ```
 
 > Note: If you have just a specific version of python installed on your system, you can test like this:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifier =
     License :: OSI Approved :: MIT License
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pep8
+envlist = py34,py35,py36,pep8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
The support of python 2.7 is soon finish. It's a new project,
it's not useful to support an old python version.