### PR TITLE
Move the common function on in a specific module.

### DIFF
--- a/kojak/cli.py
+++ b/kojak/cli.py
@@ -2,12 +2,7 @@ import argparse
 import os
 import sys
 
-
-def is_valid_path(path):
-    if not os.path.exists(path):
-        raise IOError("{path} is not a valid path".format(path=path))
-    if not os.access(path, os.R_OK):
-        raise OSError("{path} is not a readable path".format(path=path))
+from kojak.common import is_valid_path, pluralize
 
 
 class readable_path(argparse.Action):
@@ -33,18 +28,6 @@ def argparser():
     parser.add_argument('-V', '--version', action='store_true',
                         help='Only display the kojak version number')
     return parser.parse_args()
-
-
-def pluralize(iterable, singular, plural=None):
-    if not plural:
-        plural = "{singular}s".format(singular=singular)
-    if not iterable:
-        return singular
-    if isinstance(iterable, (list, tuple, dict)):
-        iterable = len(iterable)
-    elif isinstance(iterable, str):
-        iterable = int(iterable)
-    return singular if iterable == 1 else plural
 
 
 def imports(module):

--- a/kojak/common.py
+++ b/kojak/common.py
@@ -1,0 +1,35 @@
+import os
+
+
+def is_valid_path(path):
+    """To check if the path exists and if the is readable.
+
+    @param path: The path of the file or directory
+    @type path: str
+
+
+    @raise IOError: If the path doesn't exists
+    @raise OSError: If the path doesn't is not readable
+    """
+    if not os.path.exists(path):
+        raise IOError("{path} is not a valid path".format(path=path))
+    if not os.access(path, os.R_OK):
+        raise OSError("{path} is not a readable path".format(path=path))
+
+
+def pluralize(value, singular, plural=None):
+    if not value:
+        return singular
+
+    if not plural:
+        plural = "{singular}s".format(singular=singular)
+
+    if isinstance(value, (list, tuple, dict)):
+        value = len(value)
+    elif isinstance(value, str):
+        try:
+            value = int(value)
+        except ValueError:
+            value = 1
+
+    return singular if value == 1 else plural

--- a/kojak/tests/test_cli.py
+++ b/kojak/tests/test_cli.py
@@ -7,9 +7,8 @@ import unittest
 
 from kojak.cli import classes
 from kojak.cli import imports
-from kojak.cli import is_valid_path
-from kojak.cli import pluralize
 from kojak.cli import summarize
+from kojak.common import is_valid_path, pluralize
 from kojak.utils import Analyze
 from kojak.utils import Module
 
@@ -30,8 +29,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(pluralize([1], 'test', 'tests'), 'test')
         self.assertEqual(pluralize([1], 'test'), 'test')
         self.assertEqual(pluralize([], 'test', 'tests'), 'test')
-        with self.assertRaises(ValueError):
-            self.assertEqual(pluralize("ddd5", 'test', 'tests'), 'tests')
+        self.assertEqual(pluralize("ddd5", 'test', 'tests'), 'test')
 
     def test_is_valid_path(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
The is_valid_path and pluralize functions is not specific to the cli and
can be used by others things.